### PR TITLE
Greenfield Task Solution Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,6 @@ uv run routing generate --dataset "dataset-name" --model "openai/gpt-4o"
 
 - [GUIDE.md](GUIDE.md) - Setup and usage details
 - [docs/PROJECT.md](docs/PROJECT.md) - Research overview
+- [docs/TASKS.md](docs/TASKS.md) - Task types: GitHub issues and zero-shot prompts
 - [docs/OBJECTIVE.md](docs/OBJECTIVE.md) - Objective characteristic definitions
 - [docs/FILESYSTEM.md](docs/FILESYSTEM.md) - Data and output layout

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -12,14 +12,22 @@ Prompts are loaded from `docs/agent/prompts/`:
 docs/agent/
   prompts.json          # Configuration
   prompts/
-    V1.md               # Default prompt template
+    V1.md               # Default template for GitHub issues
+    V1_zero_shot.md     # Template for zero-shot prompt tasks
 ```
 
-Configuration in `prompts.json`:
+Configuration in `prompts.json`. `defaults` maps a task type to its template;
+`prompt` is the fallback when a task type has no entry:
 ```json
 {
-  "prompts": { "V1": "./prompts/V1.md" },
-  "defaults": { "prompt": "V1" }
+  "prompts": {
+    "V1": "./prompts/V1.md",
+    "V1_zero_shot": "./prompts/V1_zero_shot.md"
+  },
+  "defaults": {
+    "prompt": "V1",
+    "zero_shot": "V1_zero_shot"
+  }
 }
 ```
 

--- a/docs/FILESYSTEM.md
+++ b/docs/FILESYSTEM.md
@@ -130,6 +130,14 @@ Collected issue files live under:
 data/issues/
 ```
 
+## Prompts
+
+Zero-shot prompt datasets (see [TASKS.md](TASKS.md)) live under:
+
+```text
+data/prompts/
+```
+
 The locked judge calibration issue set is:
 
 ```text

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,0 +1,59 @@
+# Task Types
+
+The pipeline solves two kinds of tasks. Both flow through the same commands,
+storage layout, judging, and selection; they differ only in how the workspace
+is prepared and which agent prompt template is used.
+
+| Task type | Input | Workspace | Solution diff |
+|-----------|-------|-----------|---------------|
+| `github_issue` | GitHub issue with `repo` and `base_commit` | Repo cloned and checked out at `base_commit` | Changes to existing code |
+| `zero_shot` | Natural-language prompt, no code input | Empty directory with a fresh git repo | Newly created project files |
+
+The task type is stored on each task and derived automatically: rows with a
+`repo` are GitHub issues, rows without one are zero-shot prompts. It can also
+be set explicitly with a `task_type` field.
+
+## Zero-Shot Prompts
+
+Zero-shot prompts are requests to start a project or build a minimal tool from
+scratch (e.g., a CLI utility, an API script, a data-processing script). The
+prompt text can be informal or structured; the pipeline treats both as plain
+text.
+
+Prompts are stored as JSON files under `data/prompts/`:
+
+```json
+[
+  {
+    "id": "prompt__unit-converter-001",
+    "title": "Unit Converter CLI",
+    "body": "Build a command-line tool that converts between units..."
+  }
+]
+```
+
+Only `id`, `title`, and `body` are required. `title` is a short task name;
+`body` holds the full prompt text.
+
+## Usage
+
+Generation, judging, and selection use the same commands as issue tasks:
+
+```bash
+uv run routing generate --dataset data/prompts/zero_shot_20.json --model <provider/model>
+uv run routing judge --exposure V1
+uv run routing select
+```
+
+## Behavior Differences
+
+- **Generation**: instead of cloning a repository, the generator creates an
+  empty directory with an initialized git repo. The agent prompt uses the
+  `zero_shot` template registered in `docs/agent/prompts.json`, which tells
+  the model it is starting from an empty project.
+- **Solution capture**: `patch.diff` includes newly created files (captured
+  via git intent-to-add before diffing).
+- **Judging**: V1 (issue + diff) works unchanged. V2 exposures provide no
+  source files, because zero-shot tasks have no pre-existing code; V1 is the
+  natural exposure for them.
+- **Objective metrics, storage, selection**: identical to issue tasks.

--- a/docs/agent/prompts.json
+++ b/docs/agent/prompts.json
@@ -1,8 +1,10 @@
 {
     "prompts": {
-        "V1": "./prompts/V1.md"
+        "V1": "./prompts/V1.md",
+        "V1_zero_shot": "./prompts/V1_zero_shot.md"
     },
     "defaults": {
-        "prompt": "V1"
+        "prompt": "V1",
+        "zero_shot": "V1_zero_shot"
     }
 }

--- a/docs/agent/prompts/V1_zero_shot.md
+++ b/docs/agent/prompts/V1_zero_shot.md
@@ -1,0 +1,9 @@
+
+Title: <ISSUE_TITLE>
+
+Request:
+<ISSUE_BODY>
+
+You are starting from an empty project directory. Create the files needed to
+fulfill the request. Keep the project minimal: only create files the request
+actually needs.

--- a/src/cli.py
+++ b/src/cli.py
@@ -65,6 +65,13 @@ def _gather_source_files(exposure: str, folder: Path, issue, solution):
 
     if not exposure.startswith("V2"):
         return None
+    if not issue.repo:
+        # Zero-shot tasks have no pre-existing source files to expose.
+        logger.info(
+            "No repository for %s; V2 exposure has no source files",
+            issue.issue_id,
+        )
+        return {}
     if not issue.base_commit:
         raise ValueError(f"V2 requires base_commit on issue {issue.issue_id}")
     if exposure == "V2.0":

--- a/src/dataset/loader.py
+++ b/src/dataset/loader.py
@@ -53,7 +53,8 @@ class HuggingFaceIssueDataset(IssueDataset):
 class LocalIssueDataset(IssueDataset):
     """Load issues from a local JSON.
 
-    List of objects. Each one should have id, repo, number, title, body.
+    List of objects. Each one should have id, title, body. GitHub issues also
+    carry repo and number; zero-shot prompts omit them.
     """
 
     def __init__(self, path: str):
@@ -73,10 +74,12 @@ def _row_to_issue(row: dict) -> Issue:
     return Issue(
         # Required
         issue_id=str(row["id"]),
-        repo=row["repo"],
-        number=row["number"],
         title=row["title"],
         body=row["body"],
+        # GitHub fields, absent for zero-shot prompts
+        repo=row.get("repo"),
+        number=row.get("number"),
+        task_type=row.get("task_type"),
         # Optional
         labels=row.get("labels") or [],
         base_commit=str(bc) if (bc := row.get("base_commit")) else None,

--- a/src/generator.py
+++ b/src/generator.py
@@ -46,7 +46,7 @@ class SolutionGenerator:
             self._check_docker_available()
         self.environment_type = environment_type
         self.prompt_version = prompt_version
-        self._prompt_template: str | None = None
+        self._prompt_templates: dict[str, str] = {}
 
     def _check_docker_available(self) -> None:
         """Check if Docker is available and running."""
@@ -110,14 +110,7 @@ class SolutionGenerator:
         provider = model.split("/")[0] if "/" in model else "unknown"
 
         try:
-            self._clone_repo(
-                issue.repo,
-                workspace,
-                timeout=timeout,
-                base_commit=issue.base_commit,
-            )
-            if issue.base_commit:
-                self._checkout_commit(workspace, issue.base_commit, timeout=timeout)
+            self._prepare_workspace(issue, workspace, timeout=timeout)
             prompt = self._build_prompt(issue)
 
             start = time.monotonic()
@@ -151,6 +144,52 @@ class SolutionGenerator:
         finally:
             if workspace.exists():
                 self._remove_workspace(workspace)
+
+    def _prepare_workspace(
+        self,
+        issue: Issue,
+        workspace: Path,
+        timeout: int = DEFAULT_TIMEOUT,
+    ) -> None:
+        """Clone the task's repo, or init an empty repo for zero-shot tasks."""
+        if issue.repo:
+            self._clone_repo(
+                issue.repo,
+                workspace,
+                timeout=timeout,
+                base_commit=issue.base_commit,
+            )
+            if issue.base_commit:
+                self._checkout_commit(workspace, issue.base_commit, timeout=timeout)
+        else:
+            self._init_workspace(workspace, timeout=timeout)
+
+    def _init_workspace(
+        self,
+        workspace: Path,
+        timeout: int = DEFAULT_TIMEOUT,
+    ) -> None:
+        """Create an empty git workspace with an initial commit."""
+        workspace.mkdir(parents=True, exist_ok=True)
+        identity = ["-c", "user.name=routing", "-c", "user.email=routing@localhost"]
+        for cmd in (
+            ["git", "init"],
+            ["git", *identity, "commit", "--allow-empty", "-m", "Initial commit"],
+        ):
+            try:
+                subprocess.run(
+                    cmd,
+                    cwd=workspace,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                )
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(
+                    f"workspace init failed ({' '.join(cmd)}).\n"
+                    f"stderr: {e.stderr or ''}"
+                ) from e
 
     def _clone_repo(
         self,
@@ -208,25 +247,31 @@ class SolutionGenerator:
             ) from e
 
     def _make_workspace_name(self, issue: Issue) -> str:
-        safe_repo = re.sub(r"[^A-Za-z0-9._-]", "_", issue.repo or "repo")
-        safe_repo = safe_repo.strip("._-") or "repo"
-        if len(safe_repo) > 100:
-            safe_repo = safe_repo[:100]
+        base = issue.repo or issue.issue_id or "task"
+        safe_base = re.sub(r"[^A-Za-z0-9._-]", "_", base)
+        safe_base = safe_base.strip("._-") or "task"
+        if len(safe_base) > 100:
+            safe_base = safe_base[:100]
         suffix = uuid.uuid4().hex[:8]
-        return f"{safe_repo}_{issue.number}_{suffix}"
+        if issue.number:
+            return f"{safe_base}_{issue.number}_{suffix}"
+        return f"{safe_base}_{suffix}"
 
-    def _load_prompt_template(self) -> str:
-        if self._prompt_template is not None:
-            return self._prompt_template
+    def _load_prompt_template(self, task_type: str) -> str:
+        cached = self._prompt_templates.get(task_type)
+        if cached is not None:
+            return cached
 
         config = json.loads((AGENT_DIR / "prompts.json").read_text(encoding="utf-8"))
-        version = self.prompt_version or config["defaults"]["prompt"]
+        defaults = config["defaults"]
+        version = self.prompt_version or defaults.get(task_type) or defaults["prompt"]
         prompt_path = AGENT_DIR / config["prompts"][version].lstrip("./")
-        self._prompt_template = prompt_path.read_text(encoding="utf-8")
-        return self._prompt_template
+        template = prompt_path.read_text(encoding="utf-8")
+        self._prompt_templates[task_type] = template
+        return template
 
     def _build_prompt(self, issue: Issue) -> str:
-        template = self._load_prompt_template()
+        template = self._load_prompt_template(issue.task_type or "github_issue")
         return fill_template(
             template,
             {"<ISSUE_TITLE>": issue.title, "<ISSUE_BODY>": issue.body},
@@ -299,6 +344,25 @@ class SolutionGenerator:
         exposed_files = list(getattr(env, "exposed_files", []))
         grep_exposed_files = list(getattr(env, "grep_exposed_files", []))
 
+        diff = self._capture_diff(workspace)
+        return trajectory, diff, exposed_files, grep_exposed_files
+
+    def _capture_diff(self, workspace: Path) -> str:
+        """Capture the solution diff, including newly created files."""
+        try:
+            subprocess.run(
+                ["git", "add", "-N", "."],
+                cwd=workspace,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.warning(
+                "git add -N failed; new files may be missing from the diff: %s",
+                e.stderr,
+            )
+
         try:
             diff_result = subprocess.run(
                 ["git", "diff"],
@@ -307,8 +371,6 @@ class SolutionGenerator:
                 text=True,
                 check=True,
             )
-            diff = diff_result.stdout
+            return diff_result.stdout
         except subprocess.CalledProcessError as e:
-            diff = f"git diff failed (rc={e.returncode}): {e.stderr}"
-
-        return trajectory, diff, exposed_files, grep_exposed_files
+            return f"git diff failed (rc={e.returncode}): {e.stderr}"

--- a/src/models.py
+++ b/src/models.py
@@ -4,17 +4,29 @@ from dataclasses import dataclass, field
 
 from .objective import ObjectiveMetrics
 
+TASK_TYPE_GITHUB_ISSUE = "github_issue"
+TASK_TYPE_ZERO_SHOT = "zero_shot"
+
 
 @dataclass
 class Issue:
-    """A GitHub issue to solve."""
+    """A task to solve: a GitHub issue or a zero-shot project prompt.
+
+    Zero-shot prompts have no repository; `title` names the task and `body`
+    holds the full prompt text.
+    """
 
     # Required fields
     issue_id: str
-    repo: str
-    number: int
     title: str
     body: str
+
+    # GitHub fields, absent for zero-shot prompts
+    repo: str | None = None
+    number: int | None = None
+
+    # Derived from repo when not set explicitly
+    task_type: str | None = None
 
     # Optional
     labels: list[str] = field(default_factory=list)
@@ -27,6 +39,12 @@ class Issue:
     state: str | None = None  # open/closed
     comments_count: int | None = None
     reactions_count: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.task_type is None:
+            self.task_type = (
+                TASK_TYPE_GITHUB_ISSUE if self.repo else TASK_TYPE_ZERO_SHOT
+            )
 
 
 @dataclass

--- a/tests/test_cli_loaders.py
+++ b/tests/test_cli_loaders.py
@@ -3,7 +3,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from src.cli import _load_issue
+from src.cli import _gather_source_files, _load_issue
+from src.models import Issue, Solution
 
 
 class CliLoaderTest(unittest.TestCase):
@@ -29,6 +30,46 @@ class CliLoaderTest(unittest.TestCase):
             self.assertEqual(issue.issue_id, "owner__repo-1")
             self.assertEqual(issue.repo, "owner/repo")
             self.assertFalse(hasattr(issue, "assigned_reviewer"))
+
+
+class GatherSourceFilesTest(unittest.TestCase):
+    def _solution(self, issue_id):
+        return Solution(
+            issue_id=issue_id,
+            model="m/model",
+            provider="m",
+            diff="diff --git a/tool.py b/tool.py",
+            trajectory={},
+            duration_ms=1,
+            created_at="now",
+        )
+
+    def test_v1_returns_none(self):
+        issue = Issue(issue_id="prompt__x-1", title="t", body="b")
+        result = _gather_source_files(
+            "V1", Path("unused"), issue, self._solution(issue.issue_id)
+        )
+        self.assertIsNone(result)
+
+    def test_v2_returns_empty_for_zero_shot_tasks(self):
+        issue = Issue(issue_id="prompt__x-1", title="t", body="b")
+        result = _gather_source_files(
+            "V2.1", Path("unused"), issue, self._solution(issue.issue_id)
+        )
+        self.assertEqual(result, {})
+
+    def test_v2_still_requires_base_commit_for_github_issues(self):
+        issue = Issue(
+            issue_id="owner__repo-1",
+            title="t",
+            body="b",
+            repo="owner/repo",
+            number=1,
+        )
+        with self.assertRaises(ValueError):
+            _gather_source_files(
+                "V2.1", Path("unused"), issue, self._solution(issue.issue_id)
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -1,0 +1,92 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.dataset import load_issues
+from src.models import TASK_TYPE_GITHUB_ISSUE, TASK_TYPE_ZERO_SHOT, Issue
+
+
+def _write_dataset(folder: Path, rows: list[dict]) -> str:
+    path = folder / "tasks.json"
+    path.write_text(json.dumps(rows), encoding="utf-8")
+    return str(path)
+
+
+class DatasetLoaderTest(unittest.TestCase):
+    def test_loads_github_issue_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_dataset(
+                Path(tmp),
+                [
+                    {
+                        "id": "owner__repo-1",
+                        "repo": "owner/repo",
+                        "number": 1,
+                        "title": "Title",
+                        "body": "Body",
+                        "base_commit": "abc123",
+                    }
+                ],
+            )
+
+            issues = list(load_issues(path))
+
+            self.assertEqual(len(issues), 1)
+            self.assertEqual(issues[0].repo, "owner/repo")
+            self.assertEqual(issues[0].task_type, TASK_TYPE_GITHUB_ISSUE)
+            self.assertEqual(issues[0].base_commit, "abc123")
+
+    def test_loads_zero_shot_prompt_rows_without_repo(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_dataset(
+                Path(tmp),
+                [
+                    {
+                        "id": "prompt__unit-converter-001",
+                        "title": "Unit Converter CLI",
+                        "body": "Build a CLI tool that converts units...",
+                    }
+                ],
+            )
+
+            issues = list(load_issues(path))
+
+            self.assertEqual(len(issues), 1)
+            self.assertIsNone(issues[0].repo)
+            self.assertIsNone(issues[0].number)
+            self.assertIsNone(issues[0].base_commit)
+            self.assertEqual(issues[0].task_type, TASK_TYPE_ZERO_SHOT)
+
+    def test_explicit_task_type_is_kept(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_dataset(
+                Path(tmp),
+                [
+                    {
+                        "id": "prompt__x-1",
+                        "title": "T",
+                        "body": "B",
+                        "task_type": "zero_shot",
+                    }
+                ],
+            )
+
+            issues = list(load_issues(path))
+
+            self.assertEqual(issues[0].task_type, TASK_TYPE_ZERO_SHOT)
+
+
+class IssueTaskTypeTest(unittest.TestCase):
+    def test_task_type_derived_from_repo(self):
+        with_repo = Issue(
+            issue_id="a", title="t", body="b", repo="owner/repo", number=1
+        )
+        without_repo = Issue(issue_id="b", title="t", body="b")
+
+        self.assertEqual(with_repo.task_type, TASK_TYPE_GITHUB_ISSUE)
+        self.assertEqual(without_repo.task_type, TASK_TYPE_ZERO_SHOT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_generator_workspace.py
+++ b/tests/test_generator_workspace.py
@@ -1,0 +1,112 @@
+"""Workspace preparation and diff capture for both task types."""
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.generator import SolutionGenerator
+from src.models import Issue
+
+
+def _zero_shot_issue():
+    return Issue(issue_id="prompt__tool-1", title="Tool", body="Build a tool.")
+
+
+def _github_issue():
+    return Issue(
+        issue_id="owner__repo-1",
+        title="Bug",
+        body="Fix it.",
+        repo="owner/repo",
+        number=1,
+    )
+
+
+class WorkspacePreparationTest(unittest.TestCase):
+    def setUp(self):
+        self.generator = SolutionGenerator(environment_type="local")
+
+    def test_init_workspace_creates_git_repo_with_initial_commit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "ws"
+            self.generator._prepare_workspace(_zero_shot_issue(), workspace)
+
+            self.assertTrue((workspace / ".git").is_dir())
+            log = subprocess.run(
+                ["git", "log", "--oneline"],
+                cwd=workspace,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            self.assertEqual(len(log.stdout.strip().splitlines()), 1)
+
+    def test_capture_diff_includes_new_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "ws"
+            self.generator._init_workspace(workspace)
+            (workspace / "tool.py").write_text("print('hi')\n", encoding="utf-8")
+
+            diff = self.generator._capture_diff(workspace)
+
+            self.assertIn("tool.py", diff)
+            self.assertIn("print('hi')", diff)
+
+    def test_capture_diff_includes_tracked_changes_and_new_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "ws"
+            self.generator._init_workspace(workspace)
+            (workspace / "existing.py").write_text("old\n", encoding="utf-8")
+            identity = [
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@localhost",
+            ]
+            subprocess.run(
+                ["git", "add", "existing.py"],
+                cwd=workspace,
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["git", *identity, "commit", "-m", "add existing"],
+                cwd=workspace,
+                check=True,
+                capture_output=True,
+            )
+            (workspace / "existing.py").write_text("new\n", encoding="utf-8")
+            (workspace / "created.py").write_text("fresh\n", encoding="utf-8")
+
+            diff = self.generator._capture_diff(workspace)
+
+            self.assertIn("existing.py", diff)
+            self.assertIn("created.py", diff)
+
+    def test_workspace_name_falls_back_to_task_id(self):
+        name = self.generator._make_workspace_name(_zero_shot_issue())
+        self.assertTrue(name.startswith("prompt__tool-1_"))
+        self.assertNotIn("None", name)
+
+        name = self.generator._make_workspace_name(_github_issue())
+        self.assertTrue(name.startswith("owner_repo_1_"))
+
+
+class PromptTemplateTest(unittest.TestCase):
+    def setUp(self):
+        self.generator = SolutionGenerator(environment_type="local")
+
+    def test_zero_shot_tasks_use_zero_shot_template(self):
+        prompt = self.generator._build_prompt(_zero_shot_issue())
+        self.assertIn("empty project directory", prompt)
+        self.assertIn("Build a tool.", prompt)
+
+    def test_github_issues_use_default_template(self):
+        prompt = self.generator._build_prompt(_github_issue())
+        self.assertNotIn("empty project directory", prompt)
+        self.assertIn("Fix it.", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adding greenfield zero-shot prompts (no-code, natural-language project requests) as a second task type alongside GitHub issues. Same commands, storage, judging, and selection.

- Issue model generalized with task_type
- Generator inits an empty git workspace for repo-less tasks instead of cloning. patch.diff now captures newly created files via git intent-to-add
- Zero-shot agent prompt template (V1_zero_shot.md) selected per task type through docs/agent/prompts.json
- V2 judge exposure returns no source files for zero-shot tasks. V1 judging works unchanged
- Docs: new TASKS.md, updates to AGENT.md, FILESYSTEM.md, README